### PR TITLE
Use latest archiver to fix exploit

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/sole/node-zip-folder",
   "dependencies": {
-    "archiver": "^0.11.0"
+    "archiver": "^2.0.3"
   },
   "devDependencies": {
     "nodeunit": "^0.9.0",


### PR DESCRIPTION
Fixes https://nodesecurity.io/advisories/118 required by archiver@^0.11.0 > glob@~3.2.6 > minimatch@0.3

See https://github.com/electron-userland/electron-forge/issues/322